### PR TITLE
[ Style ] 메인 페이지 배너 요소 나머지 구현

### DIFF
--- a/src/assets/Rectangle.svg
+++ b/src/assets/Rectangle.svg
@@ -1,0 +1,3 @@
+<svg width="17" height="5" viewBox="0 0 17 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.319824" y="0.312378" width="16.6586" height="4.16465" fill="black"/>
+</svg>

--- a/src/assets/Slash.svg
+++ b/src/assets/Slash.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="64" viewBox="0 0 22 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21.3761 0.509304L4.24571 63.9795H0.731784L17.8622 0.509304H21.3761Z" fill="#D5D5D5"/>
+</svg>

--- a/src/components/common/Button/BookMarkListBtn.tsx
+++ b/src/components/common/Button/BookMarkListBtn.tsx
@@ -26,6 +26,7 @@ const BookMarkListBtnWrapper = styled.button`
 	width: 24.2rem;
 	height: 5.4rem;
 	border-radius: 15px;
+	color: ${({ theme }) => theme.colors.white1};
 	${({ theme }) => theme.fonts.Pretendard_Semibold_22px};
 	padding-left: 1.9rem;
 	padding-right: 4rem;

--- a/src/constants/Score.ts
+++ b/src/constants/Score.ts
@@ -1,0 +1,4 @@
+export const SCORE = [
+	{ id: 1, score: 700, text: 'REMAINING DOTORI' },
+	{ id: 2, score: 50, text: 'DOTOREAD DOTORI' },
+];

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -1,15 +1,24 @@
 import CircleGraph from './components/CircleGraph';
+import MainScore from './components/MainScore';
 import MainTitle from './components/MainTitle';
+import { SCORE } from '@/constants/Score';
 import styled from 'styled-components';
 
-function MainPage() {
+const MainPage = () => {
 	return (
 		<MainPageWrapper>
-			<MainTitle />
-			<CircleGraph />
+			<MainPageBanner>
+				<MainTitle />
+				<CircleGraph />
+				<MainScoreBox>
+					{SCORE.map(({ id, score, text }) => (
+						<MainScore key={id} score={score} text={text} />
+					))}
+				</MainScoreBox>
+			</MainPageBanner>
 		</MainPageWrapper>
 	);
-}
+};
 
 export default MainPage;
 
@@ -17,6 +26,21 @@ const MainPageWrapper = styled.div`
 	display: flex;
 	width: 100%;
 	height: 100vh;
-	gap: 6.2rem;
 	background-color: ${({ theme }) => theme.colors.background};
+`;
+
+const MainPageBanner = styled.div`
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+	height: 27.5rem;
+	padding: 2.488rem 29.6rem;
+	gap: 9.7rem;
+`;
+
+const MainScoreBox = styled.div`
+	display: flex;
+	flex-direction: column;
+	margin-top: 11rem;
+	gap: 1.154rem;
 `;

--- a/src/pages/Main/components/CircleGraph.tsx
+++ b/src/pages/Main/components/CircleGraph.tsx
@@ -11,6 +11,4 @@ function CircleGraph() {
 
 export default CircleGraph;
 
-const CircleGraphWrapper = styled.div`
-	padding-top: 3.1rem;
-`;
+const CircleGraphWrapper = styled.div``;

--- a/src/pages/Main/components/MainScore.tsx
+++ b/src/pages/Main/components/MainScore.tsx
@@ -1,0 +1,45 @@
+import RectangelIcon from '@/assets/Rectangle.svg?react';
+import SlashIcon from '@/assets/Slash.svg?react';
+import styled from 'styled-components';
+
+interface MainScoreProps {
+	score: number;
+	text: string;
+}
+
+const MainScore = ({ score, text }: MainScoreProps) => {
+	return (
+		<MainScoreWrapper>
+			<RectangelIcon />
+			<Score>{score}</Score>
+			<SlashIcon />
+			<Text>{text}</Text>
+		</MainScoreWrapper>
+	);
+};
+
+export default MainScore;
+
+const MainScoreWrapper = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 34.4rem;
+	height: 8.4126rem;
+	gap: 1.5rem;
+	border-radius: 49.976px;
+	box-shadow: 0px 3.332px 3.332px 0px rgba(0, 0, 0, 0.25) inset;
+	background-color: ${({ theme }) => theme.colors.white3};
+`;
+
+const Score = styled.p`
+	color: ${({ theme }) => theme.colors.orange1};
+	${({ theme }) => theme.fonts.Pretendard_Semibold_49px};
+`;
+
+const Text = styled.p`
+	width: 9.8rem;
+	height: 4.2rem;
+	color: ${({ theme }) => theme.colors.background};
+	${({ theme }) => theme.fonts.Pretendard_Semibold_18px};
+`;

--- a/src/pages/Main/components/MainTitle.tsx
+++ b/src/pages/Main/components/MainTitle.tsx
@@ -14,10 +14,10 @@ export default MainTitle;
 const MainTitleWrapper = styled.div`
 	display: flex;
 	width: 43.3rem;
+	min-width: 43.3rem;
 	height: 15.9rem;
 	flex-direction: column;
 	justify-content: center;
-	margin-left: 29.6rem;
 	margin-top: 3.1rem;
 `;
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -7,6 +7,7 @@ const colors = {
 
 	white1: '#FFFFFF',
 	white2: '#DEDEDE',
+	white3: '#FCFCFC',
 
 	gray1: '#3B3B3B',
 	gray2: '#5C5C5C',
@@ -22,14 +23,11 @@ const colors = {
 	bookmark_click: '#6E4A39',
 	bookmark_select: '#FFE5D9',
 
-
 	thumnail: '#D9D9D9',
 	transparent: 'rgba(0,0,0,0)',
-
 };
 
 const baseFontStyle = css`
-	color: var(--white1, #fff);
 	font-family: Pretendard;
 	font-style: normal;
 	line-height: normal;
@@ -46,6 +44,11 @@ const fonts = {
 		${baseFontStyle}
 		font-size: 20px;
 		font-weight: 700;
+	`,
+	Pretendard_Semibold_49px: css`
+		${baseFontStyle}
+		font-size: 49.976px;
+		font-weight: 600;
 	`,
 	Pretendard_Semibold_45px: css`
 		${baseFontStyle}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #21 

## ✅ 작업 리스트

- [ ] 메인페이지 배너 Score 컴포넌트 구현

## 🔧 작업 내용

### MainScore.tsx
```typescript
const MainScore = ({ score, text }: MainScoreProps) => {
	return (
		<MainScoreWrapper>
			<RectangelIcon />
			<Score>{score}</Score>
			<SlashIcon />
			<Text>{text}</Text>
		</MainScoreWrapper>
	);
};
```
score와 text를 props로 받아서 사용할 수 있게 하였습니다. 

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
<img width="329" alt="스크린샷 2024-10-30 오후 7 55 48" src="https://github.com/user-attachments/assets/c0893e34-e243-427f-aa37-a1c025cdf814">

