### PR TITLE
[ Style ] 모달 공통 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/AiClassification/AiClassificationPage.tsx
+++ b/src/components/AiClassification/AiClassificationPage.tsx
@@ -1,20 +1,35 @@
+// AiClassificationPage.tsx
 import AiClassificationBtn from '../common/Button/AiClassificationBtn';
 import Btn from '../common/Button/Btn';
+import Modal from '../common/Modal/Modal';
 import ClassificationArticle from './ClassificationArticle';
 import AiIcon from '@/assets/Ai.svg?react';
 import { AiClassifiedList } from '@/constants/AiClassificationList';
 import { Buttons } from '@/constants/ButtonList';
+import useModal from '@/hooks/useModal';
 import { useState } from 'react';
 import styled from 'styled-components';
 
 const AiClassificationPage = () => {
 	const [clickedFolders, setClickedFolders] = useState<Record<string, boolean>>({});
+	const { isOpen: isModalOpen, openModal, closeModal } = useModal();
+	const [modalContent, setModalContent] = useState<string>(''); // 모달의 제목 내용을 설정할 상태
 
 	const handleBoxClick = (folder: string) => {
 		setClickedFolders((prev) => ({
 			...prev,
 			[folder]: !prev[folder],
 		}));
+	};
+
+	const handleFinishClassify = () => {
+		setModalContent('AI 분류 완료하기'); // finishClassify 버튼 클릭 시 모달 내용 설정
+		openModal();
+	};
+
+	const handleCancelClassify = () => {
+		setModalContent('AI 분류 취소하기'); // cancelClassify 버튼 클릭 시 모달 내용 설정
+		openModal();
 	};
 
 	const groupedByFolder = AiClassifiedList.reduce(
@@ -37,8 +52,8 @@ const AiClassificationPage = () => {
 						<Title>Ai분류하기</Title>
 					</HeaderLeft>
 					<HeaderRight>
-						<Btn id="finishClassify" />
-						<Btn id="cancelClassify" />
+						<Btn id="finishClassify" onClick={handleFinishClassify} />
+						<Btn id="cancelClassify" onClick={handleCancelClassify} />
 					</HeaderRight>
 				</Header>
 				<ClassificationBtnBox>
@@ -85,6 +100,17 @@ const AiClassificationPage = () => {
 					))}
 				</ClassificationBoxWrapper>
 			</AiClassificationPageContent>
+			{/* Modal 컴포넌트 */}
+			<Modal isOpen={isModalOpen} onClose={closeModal} id="ok">
+				<ModalContent>
+					<ModalTitle>{modalContent}</ModalTitle>
+					<ModalText>
+						{modalContent === 'AI 분류 완료하기'
+							? '북마크가 모두 해당 폴더로 이동합니다.'
+							: 'AI 분류 작업을 취소하시겠습니까?'}
+					</ModalText>
+				</ModalContent>
+			</Modal>
 		</AiClassificationPageWrapper>
 	);
 };
@@ -187,4 +213,22 @@ const ClassificationArticleBox = styled.div`
 	&::-webkit-scrollbar-track {
 		background: transparent;
 	}
+`;
+
+const ModalContent = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	padding-top: 2rem;
+`;
+
+const ModalTitle = styled.h2`
+	${({ theme }) => theme.fonts.Pretendard_Semibold_30px};
+	color: ${({ theme }) => theme.colors.white1};
+`;
+
+const ModalText = styled.p`
+	${({ theme }) => theme.fonts.Pretendard_Semibold_18px};
+	color: ${({ theme }) => theme.colors.white1};
 `;

--- a/src/components/BookMarkSlide/BookMarkSlide.tsx
+++ b/src/components/BookMarkSlide/BookMarkSlide.tsx
@@ -1,4 +1,5 @@
 import BookMarkListBtn from '../common/Button/BookMarkListBtn';
+import Modal from '../common/Modal/Modal';
 import CloudIcon from '@/assets/Cloud.svg?react';
 import FolderIcon from '@/assets/Folder.svg?react';
 import LeeterIcon from '@/assets/Letter.svg?react';
@@ -6,6 +7,7 @@ import LineIcon from '@/assets/Line.svg?react';
 import LucidIcon from '@/assets/Lucide.svg?react';
 import PlusIcon from '@/assets/Plus.svg?react';
 import { FOLDER_LIST } from '@/constants/FolderList';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -15,6 +17,12 @@ interface BookMarkSlideProps {
 
 function BookMarkSlide({ show }: BookMarkSlideProps) {
 	const navigate = useNavigate();
+	const [isModalOpen, setModalOpen] = useState(false);
+	const [folderName, setFolderName] = useState('');
+
+	const handleOpenModal = () => setModalOpen(true);
+	const handleCloseModal = () => setModalOpen(false);
+
 	const handleNavigate = (text: string, iconType: string, category: string) => {
 		navigate('/bookmark', { state: { text, iconType, category } });
 	};
@@ -24,21 +32,21 @@ function BookMarkSlide({ show }: BookMarkSlideProps) {
 			<BookMarksContent>
 				<BookMarkTitle>BookMarks</BookMarkTitle>
 				<BookMarkListBtn
-					text={'모든 북마크'}
+					text="모든 북마크"
 					leftIcon={<CloudIcon />}
 					onClick={() => handleNavigate('모든 북마크', 'everyBookmark', '모든 북마크')}
-				></BookMarkListBtn>
+				/>
 				<BookMarkListBtn
-					text={'미분류'}
+					text="미분류"
 					leftIcon={<LeeterIcon />}
 					onClick={() => handleNavigate('미분류', 'unclassified', '미분류')}
-				></BookMarkListBtn>
+				/>
 			</BookMarksContent>
 			<LineIcon />
 			<FoldersContent>
 				<FoldersTitle>
 					Folders
-					<PlusIcon />
+					<PlusIcon onClick={handleOpenModal} style={{ cursor: 'pointer' }} />
 				</FoldersTitle>
 				{FOLDER_LIST.map((folder) => (
 					<BookMarkListBtn
@@ -50,6 +58,12 @@ function BookMarkSlide({ show }: BookMarkSlideProps) {
 					/>
 				))}
 			</FoldersContent>
+
+			{/* Modal */}
+			<Modal id="create" isOpen={isModalOpen} onClose={handleCloseModal}>
+				<Title>생성할 폴더 이름을 입력해주세요.</Title>
+				<Input type="text" placeholder="폴더 이름" value={folderName} onChange={(e) => setFolderName(e.target.value)} />
+			</Modal>
 		</BookMarkSlideWrapper>
 	);
 }
@@ -106,4 +120,26 @@ const FoldersTitle = styled.p`
 	color: ${({ theme }) => theme.colors.white1};
 	align-items: center;
 	justify-content: space-between;
+`;
+
+const Title = styled.h2`
+	${({ theme }) => theme.fonts.Pretendard_Semibold_30px};
+	color: ${({ theme }) => theme.colors.white1};
+`;
+
+const Input = styled.input`
+	width: 24.1rem;
+	height: 4.5rem;
+	padding: 10px;
+	border: 3px solid ${({ theme }) => theme.colors.gray2};
+	border-radius: 15px;
+	background-color: ${({ theme }) => theme.colors.background_box};
+	color: ${({ theme }) => theme.colors.white1};
+	${({ theme }) => theme.fonts.Pretendard_Medium_18px};
+	text-align: center;
+	outline: none;
+
+	::placeholder {
+		color: #555;
+	}
 `;

--- a/src/components/BookMarkSlide/BookMarkSlide.tsx
+++ b/src/components/BookMarkSlide/BookMarkSlide.tsx
@@ -7,6 +7,7 @@ import LineIcon from '@/assets/Line.svg?react';
 import LucidIcon from '@/assets/Lucide.svg?react';
 import PlusIcon from '@/assets/Plus.svg?react';
 import { FOLDER_LIST } from '@/constants/FolderList';
+import useModal from '@/hooks/useModal';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -17,11 +18,8 @@ interface BookMarkSlideProps {
 
 function BookMarkSlide({ show }: BookMarkSlideProps) {
 	const navigate = useNavigate();
-	const [isModalOpen, setModalOpen] = useState(false);
+	const { isOpen: isModalOpen, openModal, closeModal } = useModal();
 	const [folderName, setFolderName] = useState('');
-
-	const handleOpenModal = () => setModalOpen(true);
-	const handleCloseModal = () => setModalOpen(false);
 
 	const handleNavigate = (text: string, iconType: string, category: string) => {
 		navigate('/bookmark', { state: { text, iconType, category } });
@@ -46,7 +44,7 @@ function BookMarkSlide({ show }: BookMarkSlideProps) {
 			<FoldersContent>
 				<FoldersTitle>
 					Folders
-					<PlusIcon onClick={handleOpenModal} style={{ cursor: 'pointer' }} />
+					<PlusIcon onClick={openModal} style={{ cursor: 'pointer' }} />
 				</FoldersTitle>
 				{FOLDER_LIST.map((folder) => (
 					<BookMarkListBtn
@@ -60,7 +58,8 @@ function BookMarkSlide({ show }: BookMarkSlideProps) {
 			</FoldersContent>
 
 			{/* Modal */}
-			<Modal id="create" isOpen={isModalOpen} onClose={handleCloseModal}>
+			<Modal id="create" isOpen={isModalOpen} onClose={closeModal}>
+				{' '}
 				<Title>생성할 폴더 이름을 입력해주세요.</Title>
 				<Input type="text" placeholder="폴더 이름" value={folderName} onChange={(e) => setFolderName(e.target.value)} />
 			</Modal>

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,24 +1,36 @@
+import Modal from '../Modal/Modal';
 import SearchBar from './SearchBar';
 import BellIcon from '@/assets/Bell.svg?react';
 import HelpIcon from '@/assets/Help.svg?react';
 import InformationIcon from '@/assets/Information.svg?react';
 import LogoIcon from '@/assets/Logo.svg?react';
 import PlusFileIcon from '@/assets/PlusFile.svg?react';
+import useModal from '@/hooks/useModal';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 function Header() {
+	const { isOpen: isModalOpen, openModal, closeModal } = useModal();
+	const [folderName, setFolderName] = useState('');
 	return (
 		<HeaderWrapper>
 			<HeaderLeftContent>
 				<LogoIcon />
 				<SearchBar />
-				<PlusFileIcon />
+				<PlusFileIcon onClick={openModal} />
 			</HeaderLeftContent>
 			<HeaderRightContent>
 				<BellIcon />
 				<HelpIcon />
 				<InformationIcon />
 			</HeaderRightContent>
+
+			{/* Modal */}
+			<Modal id="plus" isOpen={isModalOpen} onClose={closeModal}>
+				{' '}
+				<Title>URL로 북마크 추가하기</Title>
+				<Input type="text" placeholder="http://" value={folderName} onChange={(e) => setFolderName(e.target.value)} />
+			</Modal>
 		</HeaderWrapper>
 	);
 }
@@ -46,4 +58,25 @@ const HeaderRightContent = styled.div`
 	justify-content: center;
 	align-items: center;
 	gap: 3.6rem;
+`;
+
+const Title = styled.h2`
+	${({ theme }) => theme.fonts.Pretendard_Semibold_30px};
+	color: ${({ theme }) => theme.colors.white1};
+`;
+
+const Input = styled.input`
+	width: 42.5rem;
+	height: 4.5rem;
+	padding: 10px;
+	border: 3px solid ${({ theme }) => theme.colors.gray2};
+	border-radius: 15px;
+	background-color: ${({ theme }) => theme.colors.background_box};
+	color: ${({ theme }) => theme.colors.white1};
+	${({ theme }) => theme.fonts.Pretendard_Medium_18px};
+	outline: none;
+
+	::placeholder {
+		color: #555;
+	}
 `;

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,64 @@
+import Btn from '../Button/Btn';
+import { ReactNode } from 'react';
+import ReactDOM from 'react-dom';
+import styled from 'styled-components';
+
+interface ModalProps {
+	isOpen: boolean;
+	id: string;
+	onClose: () => void;
+	children: ReactNode;
+}
+
+const Modal = ({ isOpen, onClose, id, children }: ModalProps) => {
+	if (!isOpen) return null;
+
+	return ReactDOM.createPortal(
+		<Overlay>
+			<ModalContainer>
+				<CloseButton onClick={onClose}>×</CloseButton>
+				{children}
+				<Btn id={id} />
+			</ModalContainer>
+		</Overlay>,
+		document.getElementById('modal-root') as HTMLElement,
+	);
+};
+
+export default Modal;
+
+const Overlay = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: ${({ theme }) => theme.colors.modal_background};
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1;
+`;
+
+const ModalContainer = styled.div`
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	align-items: center;
+
+	background: ${({ theme }) => theme.colors.background};
+	border-radius: 15px;
+	width: 50.4rem;
+	height: 29.5481rem;
+	padding: 6.1rem 0 3.249rem 0;
+	position: relative;
+`;
+
+const CloseButton = styled.button`
+	position: absolute;
+	top: 1rem;
+	right: 3.5rem;
+	color: ${({ theme }) => theme.colors.white1};
+	font-size: 3rem;
+	cursor: pointer;
+`;

--- a/src/constants/ButtonList.ts
+++ b/src/constants/ButtonList.ts
@@ -18,5 +18,6 @@ export const Buttons: ButtonProps[] = [
 	{ id: 'delete', text: '삭제하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
 	{ id: 'ok', text: '확인', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
 	{ id: 'finishClassify', text: '분류 완료하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
+	{ id: 'create', text: '생성하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
 	{ id: 'cancel', text: '취소하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
 ];

--- a/src/constants/ButtonList.ts
+++ b/src/constants/ButtonList.ts
@@ -20,4 +20,5 @@ export const Buttons: ButtonProps[] = [
 	{ id: 'finishClassify', text: '분류 완료하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
 	{ id: 'create', text: '생성하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
 	{ id: 'cancel', text: '취소하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
+	{ id: 'plus', text: '추가하기', color: 'white1', bordercolor: 'orange1', backgroundcolor: 'orange2' },
 ];

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+function useModal() {
+	const [isOpen, setIsOpen] = useState(false);
+
+	const openModal = () => setIsOpen(true);
+	const closeModal = () => setIsOpen(false);
+
+	return {
+		isOpen,
+		openModal,
+		closeModal,
+	};
+}
+
+export default useModal;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -26,6 +26,8 @@ const colors = {
 
 	thumnail: '#D9D9D9',
 	transparent: 'rgba(0,0,0,0)',
+
+	modal_background: 'rgba(217, 217, 217, 0.3)',
 };
 
 const baseFontStyle = css`


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #24 

## ✅ 작업 리스트

- [x] 모달 공통 컴포넌트 구현
- [x] 버튼 클릭시 모달창 연결

## 🔧 작업 내용
### Modal.tsx
```typescript
const Modal = ({ isOpen, onClose, id, children }: ModalProps) => {
	if (!isOpen) return null;

	return ReactDOM.createPortal(
		<Overlay>
			<ModalContainer>
				<CloseButton onClick={onClose}>×</CloseButton>
				{children}
				<Btn id={id} />
			</ModalContainer>
		</Overlay>,
		document.getElementById('modal-root') as HTMLElement,
	);
};
```
`createPortal `활용하여 모달 구현했습니다.
`CloseButton`을 제외한 내부 요소들은 `{children}`으로 넘겨서 사용할 수 있게하여 재사용성을 높였습니다.

### 사용법
```typescript
<Modal id="plus" isOpen={isModalOpen} onClose={closeModal}>
				{' '}
				<Title>URL로 북마크 추가하기</Title>
				<Input type="text" placeholder="http://" value={folderName} onChange={(e) => setFolderName(e.target.value)} />
</Modal>
```
모달 마다 추가되는 버튼이 다르기 때문에, id 값을 넘겨주어서 `<Btn id={id} />`에서 받아서 사용할 수 있게 하였습니다.
위 코드와 같이 Modal 태그로 감싸주고 필요한 내부요소들을 `{children}`으로 넘겨줍니다.

### useModal.ts
```typescrip
import { useState } from 'react';

function useModal() {
	const [isOpen, setIsOpen] = useState(false);

	const openModal = () => setIsOpen(true);
	const closeModal = () => setIsOpen(false);

	return {
		isOpen,
		openModal,
		closeModal,
	};
}

export default useModal;
```
Modal창 열고, 닫는 로직 커스텀훅으로 분리하여 재사용하였습니다.



## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/1afc57c6-b7e6-483e-bcb7-26bc93eca19a


https://github.com/user-attachments/assets/575186a2-8293-4429-9d18-f4b3a3ba7cae


https://github.com/user-attachments/assets/411cfc57-77bc-48b1-8021-1f2a596df341


