### PR TITLE
[feat] Ai 분류하기 페이지 연결

### DIFF
--- a/src/pages/BookMark/BookMarkList.tsx
+++ b/src/pages/BookMark/BookMarkList.tsx
@@ -11,14 +11,15 @@ interface Bookmark {
 	url: string;
 	date: string;
 }
-// 북마크 하나당 선택 가능 여부가 아니라 전체 리스트의 선택 가능여부이기에
+
 interface BookMarkListProps {
 	bookmarks: Bookmark[];
 	isSelectable: boolean;
 	isAllSelected: boolean;
+	setHasSelectedItems: (hasSelected: boolean) => void;
 }
 
-function BookMarkList({ bookmarks, isSelectable, isAllSelected }: BookMarkListProps) {
+function BookMarkList({ bookmarks, isSelectable, isAllSelected, setHasSelectedItems }: BookMarkListProps) {
 	return (
 		<BookMarkListWrapper>
 			{bookmarks.length > 0 ? (
@@ -31,6 +32,7 @@ function BookMarkList({ bookmarks, isSelectable, isAllSelected }: BookMarkListPr
 							date={bookmark.date}
 							isSelectable={isSelectable}
 							isAllSelected={isAllSelected}
+							setHasSelectedItems={setHasSelectedItems}
 						/>
 						{index < bookmarks.length - 1 && (
 							<LineWrapper>
@@ -80,4 +82,5 @@ const LineWrapper = styled.div`
 	display: flex;
 	align-items: center;
 `;
+
 const DefaultWrapperInBookMarkList = styled.div``;

--- a/src/pages/BookMark/ListItem.tsx
+++ b/src/pages/BookMark/ListItem.tsx
@@ -2,7 +2,6 @@ import Lucide from '@/assets/Lucide.svg?react';
 import LucideGray from '@/assets/LucideGray.svg?react';
 import LucideOrange from '@/assets/LucideOrange.svg?react';
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 interface ListItemProps {
@@ -12,37 +11,25 @@ interface ListItemProps {
 	date: string;
 	isSelectable: boolean;
 	isAllSelected: boolean;
+	setHasSelectedItems: (hasSelected: boolean) => void;
 }
 
-function ListItem({ name, hashtag, url, date, isSelectable, isAllSelected }: ListItemProps) {
-	const location = useLocation();
+function ListItem({ name, hashtag, url, date, isSelectable, isAllSelected, setHasSelectedItems }: ListItemProps) {
 	const [isClicked, setIsClicked] = useState(isAllSelected);
 	const IconComponent = isClicked ? LucideOrange : isSelectable ? LucideGray : Lucide;
+
 	const handleClick = () => {
 		if (isSelectable) {
-			setIsClicked(!isClicked);
+			const newClickedState = !isClicked;
+			setIsClicked(newClickedState);
+			setHasSelectedItems(newClickedState || isAllSelected);
 		}
 	};
 
-	// AI 분류하기 버튼 다시 누르면 주황 박스, 주황 음영 풀리게
-	useEffect(() => {
-		return () => {
-			setIsClicked(false);
-		};
-	}, [isSelectable]);
-
-	// 다시 전체 선택 눌렀을 때 풀리게 
-	// 근데 이미 몇개 선택 후에 눌렀을땐 나머지 listitem 선택되게
+	// 전체 선택 여부가 바뀔 때마다 상태 동기화
 	useEffect(() => {
 		setIsClicked(isAllSelected);
 	}, [isAllSelected]);
-
-	// 화면 나가면 상태 초기화
-	useEffect(() => {
-		return () => {
-			setIsClicked(false);
-		};
-	}, [location]);
 
 	return (
 		<ListItemWrapper onClick={handleClick} isClicked={isClicked}>
@@ -85,30 +72,35 @@ const Thumnail = styled.div`
 	position: absolute;
 	left: 0.8rem;
 `;
+
 const Name = styled.div`
 	color: ${({ theme }) => theme.colors.white1};
 	${({ theme }) => theme.fonts.Pretendard_Medium_18px};
 	position: absolute;
 	left: 14.7rem;
 `;
+
 const Hastag = styled.div`
 	color: ${({ theme }) => theme.colors.white1};
 	${({ theme }) => theme.fonts.Pretendard_Medium_18px};
 	position: absolute;
 	left: 22.5rem;
 `;
+
 const Url = styled.div`
 	color: ${({ theme }) => theme.colors.white1};
 	${({ theme }) => theme.fonts.Pretendard_Medium_18px};
 	position: absolute;
 	left: 50.9rem;
 `;
+
 const Date = styled.div`
 	color: ${({ theme }) => theme.colors.white1};
 	${({ theme }) => theme.fonts.Pretendard_Medium_18px};
 	position: absolute;
 	left: 109.5rem;
 `;
+
 const Icon = styled.div`
 	position: absolute;
 	right: 2.5rem;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #28 

## ✅ 작업 리스트

- [ ] Ai 분류하기 페이지 연결

## 🔧 작업 내용
### 개별 선택된 아이템 추적을 위한 상태 추가
```typescript
const [hasSelectedItems, setHasSelectedItems] = useState(false);
```
리스트 아이템 하나라도 선택되어 있으면 enter 클릭시 Ai 분류하기 페이지로 navigate
```typescript
// 선택된 항목이 있을 때 Enter 키를 눌러 /ai 경로로 이동하는 로직
	useEffect(() => {
		const handleKeyDown = (event: KeyboardEvent) => {
			if (event.key === 'Enter' && hasSelectedItems) {
				navigate('/ai');
			}
		};

		if (isAiClassifyActive) {
			window.addEventListener('keydown', handleKeyDown);
		}

		return () => {
			window.removeEventListener('keydown', handleKeyDown);
		};
	}, [isAiClassifyActive, hasSelectedItems, navigate]);
```
우선 useEffect로 구현하였는데, 추후에 수정 예정


## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/e47fb17e-93c0-4108-824a-ebbb229bd0f3


