### PR TITLE
[ Feat ] 공유 페이지 글 좋아요 , 좋아요 취소 api 연결

### DIFF
--- a/src/pages/Share/ModalContent.tsx
+++ b/src/pages/Share/ModalContent.tsx
@@ -4,6 +4,9 @@ import NicknameProfile from '@/assets/NicknameProfile.svg?react';
 import NonfillHeart from '@/assets/NonfillHeart.svg?react';
 import { useState } from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
+
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 interface Collection {
 	collectionId: number;
@@ -32,16 +35,39 @@ function formatDate(dateStr: string) {
 
 const ModalContent = ({ collection }: ModalContentProps) => {
 	const [isLiked, setIsLiked] = useState(false);
-	const [likeCount, setLikeCount] = useState(25);
+	const [likeCount, setLikeCount] = useState(0);
+	const [loading, setLoading] = useState(false);
 
-	const toggleLike = () => {
-		if (isLiked) {
-			setLikeCount(likeCount - 1);
-		} else {
-			setLikeCount(likeCount + 1);
+	const toggleLike = async () => {
+		if (loading) return;
+	
+		setLoading(true);
+		try {
+		  const accessToken = localStorage.getItem('access-token');
+		  console.log(accessToken);
+		  console.log("여기",collection.collectionId);
+		  const response = await axios.post(
+			`${BASE_URL}/api/v1/collections/like/${collection.collectionId}`,
+			{},
+			{
+				headers: { access: accessToken },
+			}
+		  );
+		  console.log(response.data);
+		  console.log("여기",collection.collectionId);
+		  if (response.data.isSuccess) {
+			setIsLiked(!isLiked); 
+			setLikeCount(isLiked ? likeCount  : likeCount + 1); 
+		  } else {
+			console.log("여기",collection.collectionId);
+			console.error('Failed to toggle like', response.data.message);
+		  }
+		} catch (error) {
+		  console.error('Error liking collection:', error);
+		} finally {
+		  setLoading(false);
 		}
-		setIsLiked(!isLiked);
-	};
+	  };
 	return (
 		<ModalContainer>
 			<Header>

--- a/src/pages/Share/ModalContent.tsx
+++ b/src/pages/Share/ModalContent.tsx
@@ -2,7 +2,7 @@ import ListItem from './ListItem';
 import FillHeart from '@/assets/FillHeart.svg?react';
 import NicknameProfile from '@/assets/NicknameProfile.svg?react';
 import NonfillHeart from '@/assets/NonfillHeart.svg?react';
-import { useState ,useEffect} from 'react';
+import { useState} from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
 
@@ -37,7 +37,7 @@ const ModalContent = ({ collection }: ModalContentProps) => {
 	const [isLiked, setIsLiked] = useState(false);
 	const [likeCount, setLikeCount] = useState(0);
 	const [loading, setLoading] = useState(false);
-	
+
 	const toggleLike = async () => {
 		if (loading) return;
 	  

--- a/src/pages/Share/ModalContent.tsx
+++ b/src/pages/Share/ModalContent.tsx
@@ -2,7 +2,7 @@ import ListItem from './ListItem';
 import FillHeart from '@/assets/FillHeart.svg?react';
 import NicknameProfile from '@/assets/NicknameProfile.svg?react';
 import NonfillHeart from '@/assets/NonfillHeart.svg?react';
-import { useState } from 'react';
+import { useState ,useEffect} from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
 
@@ -37,37 +37,57 @@ const ModalContent = ({ collection }: ModalContentProps) => {
 	const [isLiked, setIsLiked] = useState(false);
 	const [likeCount, setLikeCount] = useState(0);
 	const [loading, setLoading] = useState(false);
-
+	
 	const toggleLike = async () => {
 		if (loading) return;
-	
+	  
 		setLoading(true);
+	  
 		try {
 		  const accessToken = localStorage.getItem('access-token');
-		  console.log(accessToken);
-		  console.log("여기",collection.collectionId);
-		  const response = await axios.post(
-			`${BASE_URL}/api/v1/collections/like/${collection.collectionId}`,
-			{},
-			{
-				headers: { access: accessToken },
+		  if (!accessToken) {
+			throw new Error('Access token이 없습니다.');
+		  }
+	  
+		  if (isLiked) {
+			// 좋아요 취소 API 호출
+			const response = await axios.delete(
+			  `${BASE_URL}/api/v1/collections/like/${collection.collectionId}`,
+			  {
+				headers: { access: accessToken }
+			  }
+			);
+	  
+			if (response.data.isSuccess) {
+			  setIsLiked(false);
+			  setLikeCount((prev) => prev - 1);
+			} else {
+			  throw new Error('좋아요 취소 실패');
 			}
-		  );
-		  console.log(response.data);
-		  console.log("여기",collection.collectionId);
-		  if (response.data.isSuccess) {
-			setIsLiked(!isLiked); 
-			setLikeCount(isLiked ? likeCount  : likeCount + 1); 
 		  } else {
-			console.log("여기",collection.collectionId);
-			console.error('Failed to toggle like', response.data.message);
+			// 좋아요 추가 API 호출
+			const response = await axios.post(
+			  `${BASE_URL}/api/v1/collections/like/${collection.collectionId}`,
+			  {},
+			  {
+				headers: { access: accessToken }
+			  }
+			);
+	  
+			if (response.data.isSuccess) {
+			  setIsLiked(true);
+			  setLikeCount((prev) => prev + 1);
+			} else {
+			  throw new Error('좋아요 추가 실패');
+			}
 		  }
 		} catch (error) {
-		  console.error('Error liking collection:', error);
+		  console.error('좋아요 상태 변경 중 에러:', error);
 		} finally {
 		  setLoading(false);
 		}
 	  };
+	  
 	return (
 		<ModalContainer>
 			<Header>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #80

## ✅ 작업 리스트

- [x] 좋아요
- [x] 좋아요 취소 api 연결

## 🔧 작업 내용

1. 아직 글 상세 조회 api 연결 전이라 모달 나갔다 들어오면 좋아요 수가 +0으로 표시됩니다. 

2. 이미 좋아요 눌러둔 글에서 하트 버튼 눌러도 반영되지 않고 400에러를 반환하게 api 가구현되어있어
글 상세 조회로 얻는 isliked 값으로 모달 렌더링시 하트 모양 결정하고, isliked 값에 따라 좋아요 나 좋아요 취소 api 호출할 수 있게 수정해야합니다.

3. 또한, countlike 수 불러와서 -1 또는 +1 해줘야 합니다. 현재 useState 로 초기값 0으로 설정해뒀습니다.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/397a43b5-81a9-4756-9c8a-494d47e39116


